### PR TITLE
Added breadcrumb features and layout changes

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -20,8 +20,8 @@ class HomeController < ApplicationController
       # to 'FirstName' and 'Surname' when a plan is shared with an unknown user
       if name == 'First Name Surname'
         redirect_to edit_user_registration_path
-      else
-        redirect_to plans_url
+      #else
+      #  redirect_to plans_url
       end
     elsif session['devise.shibboleth_data'].present?
       # NOTE: Update this to handle ORCiD as well when we enable it as a login method

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,16 @@
-<div class="row">
-  <div class="col-md-8">
+<% if !user_signed_in? %>
+  <div class="row">
+    <div class="col-md-8">
+      <%= render partial: 'home/welcome' %>
+    </div>
+
+    <div class="col-md-4">
+      <%= render partial: 'shared/access_controls', locals: {orgs: @all_orgs, org_partial: @org_partial} %>
+    </div>
+  </div>
+<% else %>
+  <div class="row">
     <%= render partial: 'home/welcome' %>
   </div>
+<% end %>
 
-  <div class="col-md-4">
-    <%= render partial: 'shared/access_controls', locals: {orgs: @all_orgs, org_partial: @org_partial} %>
-  </div>
-</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,7 +10,9 @@
   </div>
 <% else %>
   <div class="row">
-    <%= render partial: 'home/welcome' %>
+    <div class="col-md-12">
+      <%= render partial: 'home/welcome' %>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -39,8 +39,11 @@
 			<ol class="breadcrumb" style="list-style: none; background-color: transparent; margin-block-start: 1em; margin-block-end: 1em; margin-inline-start: 0px; margin-inline-end: 0px;">
 				<li><a href='https://www.canada.ca/en.html'>Canada.ca</a></li>
 				<li><a style="padding: 5px 10px;" href='https://www.canada.ca/en/shared-services.html'><%= _('Shared Services Canada') %></a></li>
-				<% if !active_page?(root_path, true) %>
+				<% if user_signed_in? && !active_page?(root_path, true) %>
 					<li><a style="padding: 5px 10px;" href='/'>DMPRoadmap</a></li>
+					<% if active_page?('/plans/new', true) %>
+						<li><a style="padding: 5px 10px;" href='/plans'>My Dashboard</a></li>
+					<% end %>
 				<% end %>
 			</ol>
 		</div>


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- added a My Dashboard breadcrumb for when working within /plans
- when accessing root_path users will be directed to welcome page instead of plans page
- Remove sign in/sign up box when already signed in
- Changed the DMPRoadmap to display when in any tab other than the root welcome page
